### PR TITLE
Add contributions to hits in clusters for LCIO compliance

### DIFF
--- a/include/IO_helper.h
+++ b/include/IO_helper.h
@@ -124,12 +124,16 @@ void computeClusters(const edm4hep::CalorimeterHitCollection& calo_coll,
         position.y += calo_coll.at(index).getPosition().y;
         position.z += calo_coll.at(index).getPosition().z;
         if( EB_calo_coll->size() != 0){
-          if( index < EB_calo_coll->size() )
+          if( index < EB_calo_coll->size() ) {
             cluster.addToHits(EB_calo_coll->at(index));
-          else
+            cluster.addToHitContributions(1.0);
+          } else {
             cluster.addToHits(EE_calo_coll->at(index - EB_calo_coll->size()));
+            cluster.addToHitContributions(1.0);
+          }
         } else {
           cluster.addToHits(EE_calo_coll->at(index));
+          cluster.addToHitContributions(1.0);
         }
 
         if (calo_coll.at(index).getEnergy() > maxEnergyValue) {


### PR DESCRIPTION
In LCIO when adding a hit to a cluster, a contribution must be provided with it. See https://github.com/iLCSoft/LCIO/blob/master/src/cpp/src/IMPL/ClusterImpl.cc#L133

As EDM4hep is not aligned with this at the moment, the contribution must be manually added.